### PR TITLE
Add mongo express to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   mongodb:
-    image: mongo:4.4
+  #switch to mongo:4.4 if your pc does not have a CPU with AVX support
+    image: mongo:latest
     container_name: hackathon-mongodb
     restart: always
     ports:


### PR DESCRIPTION
- An alternative UI that we can use for the db instead of compass 
- This can be ran with docker so it doesn't need installing